### PR TITLE
Relax Rails requirement to allow Rails 6.0

### DIFF
--- a/departure.gemspec
+++ b/departure.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'railties', '~> 5.2.0'
-  spec.add_runtime_dependency 'activerecord', '~> 5.2.0'
+  spec.add_runtime_dependency 'railties', '>= 5.2.0'
+  spec.add_runtime_dependency 'activerecord', '>= 5.2.0'
   spec.add_runtime_dependency 'mysql2', '~> 0.4.0'
 
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
This is part of https://github.com/cookpad/dev-infra-squad/issues/141

This will allow us to run departure on Rails 6.0 branch.