### PR TITLE
Implement #get_full_version for Rails 6 support

### DIFF
--- a/lib/active_record/connection_adapters/percona_adapter.rb
+++ b/lib/active_record/connection_adapters/percona_adapter.rb
@@ -138,6 +138,14 @@ module ActiveRecord
       def error_number(_exception); end
 
       def full_version
+        if ActiveRecord::VERSION::MAJOR < 6
+          mysql_adapter.raw_connection.server_info[:version]
+        else
+          schema_cache.database_version.full_version_string
+        end
+      end
+
+      def get_full_version
         mysql_adapter.raw_connection.server_info[:version]
       end
 


### PR DESCRIPTION
It seems like Active Record >= 6.0 now requires this method to present, and `full_version` now return version that is cached in the schema dumper.

https://github.com/rails/rails/commit/6584fb3939dd3892834ed93fa791064d5299cda2#diff-e7dead35794529e0cc5d0b2d788f8235R132